### PR TITLE
atualiza nome do pipeline do Chromatic e refatora a configuração de t…

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,4 +1,4 @@
-name: Chromatic Deployment
+name: Chromatic Pipeline
 
 on:
   push:
@@ -8,37 +8,30 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run tests
-        run: npm test -- --coverage
+  call-tests:
+    name: Run Tests
+    uses: ./.github/workflows/main.yml
 
   chromatic:
-    needs: test
+    name: Run Chromatic
+    needs: call-tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Install dependencies
         run: npm install
 
-      - name: Publish to Chromatic
-        run: npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
+          exitOnceUploaded: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_call: {}
 
 jobs:
   test:


### PR DESCRIPTION
This pull request updates the Chromatic workflow configuration to streamline its execution and improve maintainability. The changes include renaming the workflow, restructuring job dependencies, and using reusable workflows for test execution. Additionally, it introduces a `workflow_call` trigger in the main workflow to enable its reuse.

### Workflow improvements:

* [`.github/workflows/chromatic.yml`](diffhunk://#diff-5db7bb8117a68fd50e5b5e0cbdca28ab4e360e4dd0aeba88911f9404a719700bL1-R1): Renamed the workflow from "Chromatic Deployment" to "Chromatic Pipeline" for better clarity.
* [`.github/workflows/chromatic.yml`](diffhunk://#diff-5db7bb8117a68fd50e5b5e0cbdca28ab4e360e4dd0aeba88911f9404a719700bL11-R37): Refactored the workflow to replace the inline test job with a reusable workflow (`main.yml`) for running tests, improving modularity and maintainability. The `chromatic` job was updated to depend on the new `call-tests` job.
* [`.github/workflows/chromatic.yml`](diffhunk://#diff-5db7bb8117a68fd50e5b5e0cbdca28ab4e360e4dd0aeba88911f9404a719700bL11-R37): Updated the Chromatic step to use the `chromaui/action` GitHub Action with additional parameters (`onlyChanged` and `exitOnceUploaded`) for optimized execution.

### Reusability enhancements:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R9): Added a `workflow_call` trigger to allow the main workflow to be reused in other workflows, such as the Chromatic pipeline.