### PR TITLE
Feat/publish npm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,12 +87,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           
+      - name: Setup .npmrc for GitHub Packages
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+
+      - name: Set registry to GitHub Packages
+        run: npm config set registry https://npm.pkg.github.com/
+
       - name: Publish to GitHub Packages
-        run: |
-            npm config set registry https://npm.pkg.github.com/
-            npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm publish --provenance
 
   chromatic:
     needs: test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diguinho_lns/test-ui",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "type": "git",
     "url": "git+https://github.com/DiguinhoLNS/test-ui.git"
   },
-    "publishConfig": {
+  "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
   "keywords": [],


### PR DESCRIPTION
This pull request updates the `.github/workflows/main.yml` file to streamline the process of publishing to GitHub Packages by separating the setup of the `.npmrc` file and registry configuration into distinct steps. 

Workflow improvements:

* Added a new step to set up `.npmrc` for GitHub Packages authentication using the `GITHUB_TOKEN` secret.
* Introduced a separate step to configure the npm registry to point to GitHub Packages.
* Simplified the "Publish to GitHub Packages" step by removing redundant registry configuration, as it is now handled in earlier steps.