### PR TITLE
Feat/publish npm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run tests
         run: npm test -- --coverage
 
-  publish:
+  publish-npm:
     needs: test
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -39,32 +39,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get the latest existing tag
-        id: last_tag
-        run: echo "LAST_TAG=$(git tag --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)" >> $GITHUB_ENV
-
-      - name: Compare version
-        id: compare_versions
-        run: |
-          CURRENT_TAG=${GITHUB_REF#refs/tags/}
-          LAST_TAG=${LAST_TAG:-0.0.0}  # If no previous tag, assume 0.0.0
-
-          echo "Last tag: $LAST_TAG"
-          echo "New tag: $CURRENT_TAG"
-
-          # Function to compare versions
-          version_gt() {
-            printf '%s\n%s' "$1" "$2" | sort -V | tail -n 1
-          }
-
-          if [ "$(version_gt "$CURRENT_TAG" "$LAST_TAG")" = "$CURRENT_TAG" ]; then
-            echo "The new tag is greater. Proceeding..."
-          else
-            echo "Error: The new tag ($CURRENT_TAG) is not greater than the last one ($LAST_TAG)."
-            exit 1
-          fi
-
-      - name: Setup Node.js
+      - name: Setup Node.js for npm
         uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -77,17 +52,36 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Debug NPM_AUTH_TOKEN
-        run: echo "Token is set"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
-      - name: Setup .npmrc for GitHub Packages
+
+  publish-github:
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build package
+        run: npm run build
+
+      - name: Authenticate to GitHub Packages
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
 
       - name: Set registry to GitHub Packages
@@ -96,8 +90,8 @@ jobs:
       - name: Publish to GitHub Packages
         run: npm publish --provenance
 
-  chromatic:
-    needs: test
+  publish-chromatic:
+    needs: [publish-npm, publish-github]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -106,7 +100,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@diguinho_lns/test-ui",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "version": "1.2.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,9 +19,6 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/DiguinhoLNS/test-ui.git"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
   },
   "keywords": [],
   "author": "DiguinhoLNS",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflow for publishing packages and updates the `package.json` file to align with the new workflow. The most significant changes include splitting the publishing process into separate jobs, removing redundant steps, and updating the package version.

### Workflow Refactoring:

* Renamed the `publish` job to `publish-npm` and added a new `publish-github` job to separate publishing to npm and GitHub Packages. Each job now has its own steps for setup, build, and publishing. (`.github/workflows/main.yml`, [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L29-R29) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L80-R84)
* Removed the version comparison logic in the workflow, simplifying the process of publishing based on tags. (`.github/workflows/main.yml`, [.github/workflows/main.ymlL42-R42](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L42-R42))
* Renamed the `chromatic` job to `publish-chromatic` and updated its dependencies to include both `publish-npm` and `publish-github`. (`.github/workflows/main.yml`, [.github/workflows/main.ymlL99-R94](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L99-R94))

### Package Configuration:

* Updated the `version` in `package.json` from `1.2.4` to `1.2.5`. (`package.json`, [package.jsonL3-R6](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R6))
* Moved the `publishConfig` property from the root of `package.json` to the `publish-npm` job in the workflow, ensuring it is dynamically set during the publishing process. (`package.json`, [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R6) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-L22)